### PR TITLE
Fixed issue with ES.Call for when the apply method of a function has been overridden.

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -34,6 +34,8 @@ var OrdinaryToPrimitive = function OrdinaryToPrimitive(O, hint) {
 	throw new TypeError('No default value');
 };
 
+var safeApply = Function.call.bind(Function.apply);
+
 // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-abstract-operations
 var ES6 = assign(assign({}, ES5), {
 	// https://people.mozilla.org/~jorendorff/es6-draft.html#sec-call-f-v-args
@@ -42,7 +44,7 @@ var ES6 = assign(assign({}, ES5), {
 		if (!this.IsCallable(F)) {
 			throw new TypeError(F + ' is not a function');
 		}
-		return F.apply(V, args);
+		return safeApply(F, V, args);
 	},
 
 

--- a/test/es6.js
+++ b/test/es6.js
@@ -377,7 +377,7 @@ test('IsConstructor', function (t) {
 test('Call', function (t) {
 	var receiver = {};
 	var notFuncs = objects.concat(primitives).concat([/a/g, new RegExp('a', 'g')]);
-	t.plan(notFuncs.length + 4);
+	t.plan(notFuncs.length + 5);
 	forEach(notFuncs, function (notFunc) {
 		t.throws(function () { return ES.Call(notFunc, receiver); }, TypeError, notFunc + ' (' + typeof notFunc + ') is not callable');
 	});
@@ -387,5 +387,14 @@ test('Call', function (t) {
 		t.equal(arguments.length, 3, 'extra argument was passed');
 		t.equal(arguments[2], 3, 'extra argument was correct');
 	}, receiver, [1, 2, 3]);
+
+  function withoutApply() {
+    t.equal(this, receiver, 'context matches expected');
+  }
+
+  withoutApply.apply = null;
+
+  ES.Call(withoutApply, receiver);
+
 	t.end();
 });


### PR DESCRIPTION
Added test using ES.Call with a function object with the apply property overridden. Added a safeApply function since the internal [[Call]] operation should work regardless of function properties.