### PR TITLE
[New] `ES2021+`: `IterableToList`: make `method` parameter optional

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -716,7 +716,6 @@
 2021/IsStringPrefix.js	spackled linguist-generated=true
 2021/IsUnclampedIntegerElementType.js	spackled linguist-generated=true
 2021/IsUnsignedElementType.js	spackled linguist-generated=true
-2021/IterableToList.js	spackled linguist-generated=true
 2021/IteratorClose.js	spackled linguist-generated=true
 2021/IteratorComplete.js	spackled linguist-generated=true
 2021/IteratorNext.js	spackled linguist-generated=true

--- a/2021/IterableToList.js
+++ b/2021/IterableToList.js
@@ -7,10 +7,15 @@ var GetIterator = require('./GetIterator');
 var IteratorStep = require('./IteratorStep');
 var IteratorValue = require('./IteratorValue');
 
-// https://262.ecma-international.org/9.0/#sec-iterabletolist
+// https://262.ecma-international.org/12.0/#sec-iterabletolist
 
-module.exports = function IterableToList(items, method) {
-	var iterator = GetIterator(items, 'sync', method);
+module.exports = function IterableToList(items) {
+	var iterator;
+	if (arguments.length > 1) {
+		iterator = GetIterator(items, 'sync', arguments[1]);
+	} else {
+		iterator = GetIterator(items, 'sync');
+	}
 	var values = [];
 	var next = true;
 	while (next) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -7912,6 +7912,18 @@ var es2021 = function ES2021(ES, ops, expectedMissing, skips) {
 		t.end();
 	});
 
+	test('IterableToList', function (t) {
+		// see ES2017 tests for the rest of the IterableToList tests
+
+		t.deepEqual(
+			ES.IterableToList(['a', 'b', 'c']),
+			['a', 'b', 'c'],
+			'method is optional in ES2021+'
+		);
+
+		t.end();
+	});
+
 	test('SetFunctionLength', function (t) {
 		forEach(v.nonFunctions, function (nonFunction) {
 			t['throws'](


### PR DESCRIPTION
This makes it possible to call `IterableToList` without passing `method`.

## Specification:
- https://tc39.es/proposal-promise-any/#sec-iterabletolist