### PR TITLE
[Breaking] `ES2018+`: `GetIterator`, `IterableToList`, `IteratorNext`, `IteratorStep`, `IteratorClose`: use iterator records instead

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -273,7 +273,6 @@
 2018/DeletePropertyOrThrow.js	spackled linguist-generated=true
 2018/FromPropertyDescriptor.js	spackled linguist-generated=true
 2018/Get.js	spackled linguist-generated=true
-2018/GetIterator.js	spackled linguist-generated=true
 2018/GetMethod.js	spackled linguist-generated=true
 2018/GetOwnPropertyKeys.js	spackled linguist-generated=true
 2018/GetPrototypeFromConstructor.js	spackled linguist-generated=true
@@ -296,11 +295,7 @@
 2018/IsPromise.js	spackled linguist-generated=true
 2018/IsPropertyKey.js	spackled linguist-generated=true
 2018/IsRegExp.js	spackled linguist-generated=true
-2018/IterableToList.js	spackled linguist-generated=true
-2018/IteratorClose.js	spackled linguist-generated=true
 2018/IteratorComplete.js	spackled linguist-generated=true
-2018/IteratorNext.js	spackled linguist-generated=true
-2018/IteratorStep.js	spackled linguist-generated=true
 2018/IteratorValue.js	spackled linguist-generated=true
 2018/MakeDate.js	spackled linguist-generated=true
 2018/MakeDay.js	spackled linguist-generated=true

--- a/2018/GetIterator.js
+++ b/2018/GetIterator.js
@@ -2,34 +2,69 @@
 
 var GetIntrinsic = require('../GetIntrinsic');
 
+var $asyncIterator = GetIntrinsic('%Symbol.asyncIterator%', true);
+var $SyntaxError = GetIntrinsic('%SyntaxError%');
 var $TypeError = GetIntrinsic('%TypeError%');
 
 var getIteratorMethod = require('../helpers/getIteratorMethod');
 var AdvanceStringIndex = require('./AdvanceStringIndex');
 var Call = require('./Call');
+var CreateAsyncFromSyncIterator = require('./CreateAsyncFromSyncIterator');
 var GetMethod = require('./GetMethod');
+var GetV = require('./GetV');
 var IsArray = require('./IsArray');
 var Type = require('./Type');
 
 // https://ecma-international.org/ecma-262/6.0/#sec-getiterator
 
-module.exports = function GetIterator(obj, method) {
-	var actualMethod = method;
-	if (arguments.length < 2) {
-		actualMethod = getIteratorMethod(
-			{
-				AdvanceStringIndex: AdvanceStringIndex,
-				GetMethod: GetMethod,
-				IsArray: IsArray,
-				Type: Type
-			},
-			obj
-		);
+module.exports = function GetIterator(obj) {
+	var hint = arguments.length > 1 ? arguments[1] : 'sync';
+	if (hint !== 'sync' && hint !== 'async') {
+		throw new $TypeError('Assertion failed: `hint` must be either ~sync~ or ~async~');
 	}
-	var iterator = Call(actualMethod, obj);
+	var method;
+	if (arguments.length < 3) {
+		if (hint === 'async') {
+			if (!$asyncIterator) {
+				method = GetMethod(obj, $asyncIterator);
+			}
+			if (typeof method !== 'undefined') {
+				var syncMethod = getIteratorMethod(
+					{
+						AdvanceStringIndex: AdvanceStringIndex,
+						GetMethod: GetMethod,
+						IsArray: IsArray,
+						Type: Type
+					},
+					obj
+				);
+				var syncIteratorRecord = GetIterator(obj, 'sync', syncMethod);
+				return CreateAsyncFromSyncIterator(syncIteratorRecord);
+			}
+		} else {
+			method = getIteratorMethod(
+				{
+					AdvanceStringIndex: AdvanceStringIndex,
+					GetMethod: GetMethod,
+					IsArray: IsArray,
+					Type: Type
+				},
+				obj
+			);
+		}
+	}
+	var iterator = Call(method, obj);
 	if (Type(iterator) !== 'Object') {
 		throw new $TypeError('iterator must return an object');
 	}
 
-	return iterator;
+	var nextMethod = GetV(iterator, 'next');
+
+	var iteratorRecord = {
+		'[[Iterator]]': iterator,
+		'[[NextMethod]]': nextMethod,
+		'[[Done]]': false
+	};
+
+	return iteratorRecord;
 };

--- a/2018/IterableToList.js
+++ b/2018/IterableToList.js
@@ -7,14 +7,14 @@ var GetIterator = require('./GetIterator');
 var IteratorStep = require('./IteratorStep');
 var IteratorValue = require('./IteratorValue');
 
-// https://www.ecma-international.org/ecma-262/8.0/#sec-iterabletolist
+// https://www.ecma-international.org/ecma-262/9.0/#sec-iterabletolist
 
 module.exports = function IterableToList(items, method) {
-	var iterator = GetIterator(items, method);
+	var iteratorRecord = GetIterator(items, 'sync', method);
 	var values = [];
 	var next = true;
 	while (next) {
-		next = IteratorStep(iterator);
+		next = IteratorStep(iteratorRecord);
 		if (next) {
 			var nextValue = IteratorValue(next);
 			$arrayPush(values, nextValue);

--- a/2018/IteratorClose.js
+++ b/2018/IteratorClose.js
@@ -9,10 +9,10 @@ var GetMethod = require('./GetMethod');
 var IsCallable = require('./IsCallable');
 var Type = require('./Type');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratorclose
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratorclose
 
-module.exports = function IteratorClose(iterator, completion) {
-	if (Type(iterator) !== 'Object') {
+module.exports = function IteratorClose(iteratorRecord, completion) {
+	if (Type(iteratorRecord['[[Iterator]]']) !== 'Object') {
 		throw new $TypeError('Assertion failed: Type(iterator) is not Object');
 	}
 	if (!IsCallable(completion)) {
@@ -20,6 +20,7 @@ module.exports = function IteratorClose(iterator, completion) {
 	}
 	var completionThunk = completion;
 
+	var iterator = iteratorRecord['[[Iterator]]'];
 	var iteratorReturn = GetMethod(iterator, 'return');
 
 	if (typeof iteratorReturn === 'undefined') {

--- a/2018/IteratorNext.js
+++ b/2018/IteratorNext.js
@@ -4,13 +4,19 @@ var GetIntrinsic = require('../GetIntrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
 
-var Invoke = require('./Invoke');
+var Call = require('./Call');
 var Type = require('./Type');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratornext
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratornext
 
-module.exports = function IteratorNext(iterator, value) {
-	var result = Invoke(iterator, 'next', arguments.length < 2 ? [] : [value]);
+module.exports = function IteratorNext(iteratorRecord) {
+	var value;
+	if (arguments.length > 1) {
+		value = arguments[1];
+	}
+	var result = arguments.length < 2
+		? Call(iteratorRecord['[[NextMethod]]'], iteratorRecord['[[Iterator]]'], [])
+		: Call(iteratorRecord['[[NextMethod]]'], iteratorRecord['[[Iterator]]'], [value]);
 	if (Type(result) !== 'Object') {
 		throw new $TypeError('iterator next must return an object');
 	}

--- a/2018/IteratorStep.js
+++ b/2018/IteratorStep.js
@@ -3,11 +3,10 @@
 var IteratorComplete = require('./IteratorComplete');
 var IteratorNext = require('./IteratorNext');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratorstep
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratorstep
 
-module.exports = function IteratorStep(iterator) {
-	var result = IteratorNext(iterator);
+module.exports = function IteratorStep(iteratorRecord) {
+	var result = IteratorNext(iteratorRecord);
 	var done = IteratorComplete(result);
 	return done === true ? false : result;
 };
-

--- a/2019/GetIterator.js
+++ b/2019/GetIterator.js
@@ -7,29 +7,60 @@ var $TypeError = GetIntrinsic('%TypeError%');
 var getIteratorMethod = require('../helpers/getIteratorMethod');
 var AdvanceStringIndex = require('./AdvanceStringIndex');
 var Call = require('./Call');
+var CreateAsyncFromSyncIterator = require('./CreateAsyncFromSyncIterator');
 var GetMethod = require('./GetMethod');
+var GetV = require('./GetV');
 var IsArray = require('./IsArray');
 var Type = require('./Type');
 
 // https://ecma-international.org/ecma-262/6.0/#sec-getiterator
 
-module.exports = function GetIterator(obj, method) {
-	var actualMethod = method;
-	if (arguments.length < 2) {
-		actualMethod = getIteratorMethod(
-			{
-				AdvanceStringIndex: AdvanceStringIndex,
-				GetMethod: GetMethod,
-				IsArray: IsArray,
-				Type: Type
-			},
-			obj
-		);
+module.exports = function GetIterator(obj) {
+	var hint = arguments.length > 1 ? arguments[1] : 'sync';
+	if (hint !== 'sync' && hint !== 'async') {
+		throw new $TypeError('Assertion failed: `hint` must be either ~sync~ or ~async~');
 	}
-	var iterator = Call(actualMethod, obj);
+	var method;
+	if (arguments.length < 3) {
+		if (hint === 'async') {
+			method = GetMethod(obj, Symbol.asyncIterator);
+			if (typeof method !== 'undefined') {
+				var syncMethod = getIteratorMethod(
+					{
+						AdvanceStringIndex: AdvanceStringIndex,
+						GetMethod: GetMethod,
+						IsArray: IsArray,
+						Type: Type
+					},
+					obj
+				);
+				var syncIteratorRecord = GetIterator(obj, 'sync', syncMethod);
+				return CreateAsyncFromSyncIterator(syncIteratorRecord);
+			}
+		} else {
+			method = getIteratorMethod(
+				{
+					AdvanceStringIndex: AdvanceStringIndex,
+					GetMethod: GetMethod,
+					IsArray: IsArray,
+					Type: Type
+				},
+				obj
+			);
+		}
+	}
+	var iterator = Call(method, obj);
 	if (Type(iterator) !== 'Object') {
 		throw new $TypeError('iterator must return an object');
 	}
 
-	return iterator;
+	var nextMethod = GetV(iterator, 'next');
+
+	var iteratorRecord = {
+		'[[Iterator]]': iterator,
+		'[[NextMethod]]': nextMethod,
+		'[[Done]]': false
+	};
+
+	return iteratorRecord;
 };

--- a/2019/IterableToList.js
+++ b/2019/IterableToList.js
@@ -7,14 +7,14 @@ var GetIterator = require('./GetIterator');
 var IteratorStep = require('./IteratorStep');
 var IteratorValue = require('./IteratorValue');
 
-// https://www.ecma-international.org/ecma-262/8.0/#sec-iterabletolist
+// https://www.ecma-international.org/ecma-262/9.0/#sec-iterabletolist
 
 module.exports = function IterableToList(items, method) {
-	var iterator = GetIterator(items, method);
+	var iteratorRecord = GetIterator(items, 'sync', method);
 	var values = [];
 	var next = true;
 	while (next) {
-		next = IteratorStep(iterator);
+		next = IteratorStep(iteratorRecord);
 		if (next) {
 			var nextValue = IteratorValue(next);
 			$arrayPush(values, nextValue);

--- a/2019/IteratorClose.js
+++ b/2019/IteratorClose.js
@@ -9,10 +9,10 @@ var GetMethod = require('./GetMethod');
 var IsCallable = require('./IsCallable');
 var Type = require('./Type');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratorclose
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratorclose
 
-module.exports = function IteratorClose(iterator, completion) {
-	if (Type(iterator) !== 'Object') {
+module.exports = function IteratorClose(iteratorRecord, completion) {
+	if (Type(iteratorRecord['[[Iterator]]']) !== 'Object') {
 		throw new $TypeError('Assertion failed: Type(iterator) is not Object');
 	}
 	if (!IsCallable(completion)) {
@@ -20,6 +20,7 @@ module.exports = function IteratorClose(iterator, completion) {
 	}
 	var completionThunk = completion;
 
+	var iterator = iteratorRecord['[[Iterator]]'];
 	var iteratorReturn = GetMethod(iterator, 'return');
 
 	if (typeof iteratorReturn === 'undefined') {

--- a/2019/IteratorNext.js
+++ b/2019/IteratorNext.js
@@ -4,13 +4,19 @@ var GetIntrinsic = require('../GetIntrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
 
-var Invoke = require('./Invoke');
+var Call = require('./Call');
 var Type = require('./Type');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratornext
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratornext
 
-module.exports = function IteratorNext(iterator, value) {
-	var result = Invoke(iterator, 'next', arguments.length < 2 ? [] : [value]);
+module.exports = function IteratorNext(iteratorRecord) {
+	var value;
+	if (arguments.length > 1) {
+		value = arguments[1];
+	}
+	var result = arguments.length < 2
+		? Call(iteratorRecord['[[NextMethod]]'], iteratorRecord['[[Iterator]]'], [])
+		: Call(iteratorRecord['[[NextMethod]]'], iteratorRecord['[[Iterator]]'], [value]);
 	if (Type(result) !== 'Object') {
 		throw new $TypeError('iterator next must return an object');
 	}

--- a/2019/IteratorStep.js
+++ b/2019/IteratorStep.js
@@ -3,11 +3,10 @@
 var IteratorComplete = require('./IteratorComplete');
 var IteratorNext = require('./IteratorNext');
 
-// https://ecma-international.org/ecma-262/6.0/#sec-iteratorstep
+// https://ecma-international.org/ecma-262/9.0/#sec-iteratorstep
 
-module.exports = function IteratorStep(iterator) {
-	var result = IteratorNext(iterator);
+module.exports = function IteratorStep(iteratorRecord) {
+	var result = IteratorNext(iteratorRecord);
 	var done = IteratorComplete(result);
 	return done === true ? false : result;
 };
-


### PR DESCRIPTION
## Depends on:
- [ ] <https://github.com/ljharb/es-abstract/pull/67>
- [ ] <https://github.com/ljharb/es-abstract/pull/105>

---

**BREAKING CHANGE:** This is backwards incompatible, as **ES2017** and older operated directly on the `Iterator` instance.