### PR TITLE
[Fix] `helpers/OwnPropertyKeys`: Use `Reflect.ownKeys(…)` if available

### DIFF
--- a/helpers/OwnPropertyKeys.js
+++ b/helpers/OwnPropertyKeys.js
@@ -5,6 +5,7 @@ var GetIntrinsic = require('../GetIntrinsic');
 var callBind = require('./callBind');
 var callBound = require('./callBound');
 
+var $ownKeys = GetIntrinsic('%Reflect.ownKeys%', true);
 var $pushApply = callBind.apply(GetIntrinsic('%Array.prototype.push%'));
 var $SymbolValueOf = callBound('Symbol.prototype.valueOf', true);
 var $gOPN = GetIntrinsic('%Object.getOwnPropertyNames%', true);
@@ -12,7 +13,7 @@ var $gOPS = $SymbolValueOf ? GetIntrinsic('%Object.getOwnPropertySymbols%') : nu
 
 var keys = require('object-keys');
 
-module.exports = function OwnPropertyKeys(source) {
+module.exports = $ownKeys || function OwnPropertyKeys(source) {
 	var ownKeys = ($gOPN || keys)(source);
 	if ($gOPS) {
 		$pushApply(ownKeys, $gOPS(source));


### PR DESCRIPTION
This is because <code>[Object.getOwnPropertyNames]\(<var>target</var>)</code> and <code>[Object.getOwnPropertySymbols]\(<var>target</var>)</code> both invoke <code><var>target</var>.\[\[OwnPropertyKeys\]\]\(\)</code>, which <code>[Reflect.ownKeys]\(<var>target</var>)</code> does only once, which is observable when using Proxies.

This will also make the `OwnPropertyKeys` helper throw a `TypeError` for non‑`object` targets in all **ECMAScript** environments, instead of just in **ES5** environments.

[Object.getOwnPropertyNames]: https://tc39.es/ecma262/#sec-object.getownpropertynames
[Object.getOwnPropertySymbols]: https://tc39.es/ecma262/#sec-object.getownpropertysymbols
[Reflect.ownKeys]: https://tc39.es/ecma262/#sec-reflect.ownkeys

---

review?(@ljharb)