### PR TITLE
[Fix] `helpers/getSymbolDescription`: use the global Symbol registry when available

### DIFF
--- a/helpers/getSymbolDescription.js
+++ b/helpers/getSymbolDescription.js
@@ -5,26 +5,37 @@ var GetIntrinsic = require('../GetIntrinsic');
 var callBound = require('./callBound');
 
 var $SyntaxError = GetIntrinsic('%SyntaxError%');
+var getGlobalSymbolDescription = GetIntrinsic('%Symbol.keyFor%', true);
+var thisSymbolValue = callBound('%Symbol.prototype.valueOf%', true);
 var symToStr = callBound('Symbol.prototype.toString', true);
 
 var getInferredName = require('./getInferredName');
 
+/* eslint-disable consistent-return */
 module.exports = callBound('%Symbol.prototype.description%', true) || function getSymbolDescription(symbol) {
-	if (!symToStr) {
+	if (!thisSymbolValue) {
 		throw new $SyntaxError('Symbols are not supported in this environment');
 	}
-	var str = symToStr(symbol); // will throw if not a symbol
+
+	// will throw if not a symbol primitive or wrapper object
+	var sym = thisSymbolValue(symbol);
 
 	if (getInferredName) {
-		var name = getInferredName(symbol);
+		var name = getInferredName(sym);
 		if (name === '') { return; }
-		// eslint-disable-next-line consistent-return
 		return name.slice(1, -1); // name.slice('['.length, -']'.length);
 	}
 
-	var desc = str.slice(7, -1); // str.slice('Symbol('.length, -')'.length);
+	var desc;
+	if (getGlobalSymbolDescription) {
+		desc = getGlobalSymbolDescription(sym);
+		if (typeof desc === 'string') {
+			return desc;
+		}
+	}
+
+	desc = symToStr(sym).slice(7, -1); // str.slice('Symbol('.length, -')'.length);
 	if (desc) {
-		// eslint-disable-next-line consistent-return
 		return desc;
 	}
 };

--- a/test/helpers/getSymbolDescription.js
+++ b/test/helpers/getSymbolDescription.js
@@ -49,14 +49,14 @@ test('getSymbolDescription', function (t) {
 		}, function (s2t) {
 			s2t.equal(getSymbolDescription(Symbol('')), '', 'Symbol("") description is ""');
 
-			s2t.test('only possible when global symbols are supported', {
-				skip: !has(Symbol, 'for') || !has(Symbol, 'keyFor')
-			}, function (s3t) {
-				// eslint-disable-next-line no-restricted-properties
-				s3t.equal(getSymbolDescription(Symbol['for']('')), '', 'Symbol.for("") description is ""');
-				s3t.end();
-			});
+			s2t.end();
+		});
 
+		st.test('only possible when global symbols are supported', {
+			skip: !has(Symbol, 'for') || !has(Symbol, 'keyFor')
+		}, function (s2t) {
+			// eslint-disable-next-line no-restricted-properties
+			s2t.equal(getSymbolDescription(Symbol['for']('')), '', 'Symbol.for("") description is ""');
 			s2t.end();
 		});
 


### PR DESCRIPTION
This changes `getSymbolDescription` to be a call bound `%Symbol.prototype.description%` in **ES2019+** environments, and adds a fallback to use `Symbol.keyFor` to get the `[[Description]]` internal slot value of global symbols in pre‑**ES2019** environments that support symbols.