### PR TITLE
[Fix] `ES5+`: Use spec‑accurate `IsCallable`

### DIFF
--- a/2015/IsCallable.js
+++ b/2015/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/2016/IsCallable.js
+++ b/2016/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/2017/IsCallable.js
+++ b/2017/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/2018/IsCallable.js
+++ b/2018/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/2019/IsCallable.js
+++ b/2019/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/5/IsCallable.js
+++ b/5/IsCallable.js
@@ -1,5 +1,14 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var callBound = require('../helpers/callBound.js');
+
+var $toStr = callBound('%Object.prototype.toString%');
+
 // http://www.ecma-international.org/ecma-262/5.1/#sec-9.11
 
-module.exports = require('is-callable');
+module.exports = function IsCallable(argument) {
+	// some older engines say that typeof /abc/ === 'function',
+	return typeof argument === 'function'
+		&& (hasSymbols || $toStr(argument) !== '[object RegExp]');
+};

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"function-bind": "^1.1.1",
 		"has": "^1.0.3",
 		"has-symbols": "^1.0.1",
-		"is-callable": "^1.2.0",
 		"is-regex": "^1.1.0",
 		"object-inspect": "^1.7.0",
 		"object-keys": "^1.1.1",

--- a/test/es5.js
+++ b/test/es5.js
@@ -171,10 +171,26 @@ test('CheckObjectCoercible', function (t) {
 
 test('IsCallable', function (t) {
 	t.equal(true, ES.IsCallable(function () {}), 'function is callable');
-	var nonCallables = [/a/g, {}, Object.prototype, NaN].concat(v.primitives);
+	var nonCallables = [/a/g, {}, Object.prototype, NaN].concat(v.nonFunctions);
 	forEach(nonCallables, function (nonCallable) {
 		t.equal(false, ES.IsCallable(nonCallable), debug(nonCallable) + ' is not callable');
 	});
+
+	var foo;
+	try {
+		foo = Function('return () => {}')(); // eslint-disable-line no-new-func
+		t.equal(ES.IsCallable(foo), true, 'arrow function is callable');
+	} catch (e) {
+		t.comment('SKIP: arrow function syntax not supported.');
+	}
+
+	try {
+		foo = Function('return class Foo {}')(); // eslint-disable-line no-new-func
+		t.equal(ES.IsCallable(foo), true, 'class is callable');
+	} catch (e) {
+		t.comment('SKIP: class syntax not supported.');
+	}
+
 	t.end();
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -455,6 +455,22 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 		forEach(nonCallables, function (nonCallable) {
 			t.equal(false, ES.IsCallable(nonCallable), debug(nonCallable) + ' is not callable');
 		});
+
+		var foo;
+		try {
+			foo = Function('return () => {}')(); // eslint-disable-line no-new-func
+			t.equal(ES.IsCallable(foo), true, 'arrow function is callable');
+		} catch (e) {
+			t.comment('SKIP: arrow function syntax not supported.');
+		}
+
+		try {
+			foo = Function('return class Foo {}')(); // eslint-disable-line no-new-func
+			t.equal(ES.IsCallable(foo), true, 'class is callable');
+		} catch (e) {
+			t.comment('SKIP: class syntax not supported.');
+		}
+
 		t.end();
 	});
 


### PR DESCRIPTION
The `IsConstructor` implementation is based on the one in <https://github.com/tc39/ecma262/issues/1798#issuecomment-559914634>

---

Fixes <https://github.com/ljharb/es-abstract/issues/48>