### PR TITLE
[Fix] `2016`: Use `getIteratorMethod` in `IterableToArrayLike`

### DIFF
--- a/2016/IterableToArrayLike.js
+++ b/2016/IterableToArrayLike.js
@@ -1,16 +1,9 @@
 'use strict';
 
-var GetIntrinsic = require('../GetIntrinsic');
-
-var $iterator = GetIntrinsic('%Symbol.iterator%', true);
-
 var callBound = require('../helpers/callBound');
-
-var $arrayJoin = callBound('Array.prototype.join');
 var $arrayPush = callBound('Array.prototype.push');
-var $stringSlice = callBound('String.prototype.slice');
-var $stringSplit = callBound('String.prototype.split');
 
+var getIteratorMethod = require('../helpers/getIteratorMethod');
 var AdvanceStringIndex = require('./AdvanceStringIndex');
 var GetIterator = require('./GetIterator');
 var GetMethod = require('./GetMethod');
@@ -19,43 +12,32 @@ var IteratorStep = require('./IteratorStep');
 var IteratorValue = require('./IteratorValue');
 var ToObject = require('./ToObject');
 var Type = require('./Type');
+var ES = {
+	AdvanceStringIndex: AdvanceStringIndex,
+	GetMethod: GetMethod,
+	IsArray: IsArray,
+	Type: Type
+};
 
 // https://www.ecma-international.org/ecma-262/7.0/#sec-iterabletoarraylike
+/**
+ * 1. Let usingIterator be ? GetMethod(items, @@iterator).
+ * 2. If usingIterator is not undefined, then
+ *    1. Let iterator be ? GetIterator(items, usingIterator).
+ *    2. Let values be a new empty List.
+ *    3. Let next be true.
+ *    4. Repeat, while next is not false
+ *       1. Let next be ? IteratorStep(iterator).
+ *       2. If next is not false, then
+ *          1. Let nextValue be ? IteratorValue(next).
+ *          2. Append nextValue to the end of the List values.
+ *    5. Return CreateArrayFromList(values).
+ * 3. NOTE: items is not an Iterable so assume it is already an array-like object.
+ * 4. Return ! ToObject(items).
+ */
 
 module.exports = function IterableToArrayLike(items) {
-	var usingIterator;
-	if ($iterator) {
-		usingIterator = GetMethod(items, $iterator);
-	} else if (IsArray(items)) {
-		usingIterator = function () {
-			var i = -1;
-			var arr = this; // eslint-disable-line no-invalid-this
-			return {
-				next: function () {
-					i += 1;
-					return {
-						done: i >= arr.length,
-						value: arr[i]
-					};
-				}
-			};
-		};
-	} else if (Type(items) === 'String') {
-		usingIterator = function () {
-			var i = 0;
-			return {
-				next: function () {
-					var nextIndex = AdvanceStringIndex(items, i, true);
-					var value = $arrayJoin($stringSplit($stringSlice(items, i, nextIndex), ''), '');
-					i = nextIndex;
-					return {
-						done: nextIndex > items.length,
-						value: value
-					};
-				}
-			};
-		};
-	}
+	var usingIterator = getIteratorMethod(ES, items);
 	if (typeof usingIterator !== 'undefined') {
 		var iterator = GetIterator(items, usingIterator);
 		var values = [];


### PR DESCRIPTION
This removes code duplication and ensures that any improvements to `getIteratorMethod` propagate to `IterableToArrayLike`.