### PR TITLE
[Fix]: Use `Reflect.apply(…)` if available

### DIFF
--- a/2015/Call.js
+++ b/2015/Call.js
@@ -1,19 +1,13 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
+var callBound = require('../helpers/callBound');
 
-var $TypeError = GetIntrinsic('%TypeError%');
-
-var inspect = require('object-inspect');
-
-var IsCallable = require('./IsCallable');
+var $apply = GetIntrinsic('%Reflect.apply%', true) || callBound('%Function.prototype.apply%');
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-call
 
 module.exports = function Call(F, V) {
 	var args = arguments.length > 2 ? arguments[2] : [];
-	if (!IsCallable(F)) {
-		throw new $TypeError(inspect(F) + ' is not a function');
-	}
-	return F.apply(V, args);
+	return $apply(F, V, args);
 };

--- a/2016/Call.js
+++ b/2016/Call.js
@@ -1,19 +1,13 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
+var callBound = require('../helpers/callBound');
 
-var $TypeError = GetIntrinsic('%TypeError%');
-
-var inspect = require('object-inspect');
-
-var IsCallable = require('./IsCallable');
+var $apply = GetIntrinsic('%Reflect.apply%', true) || callBound('%Function.prototype.apply%');
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-call
 
 module.exports = function Call(F, V) {
 	var args = arguments.length > 2 ? arguments[2] : [];
-	if (!IsCallable(F)) {
-		throw new $TypeError(inspect(F) + ' is not a function');
-	}
-	return F.apply(V, args);
+	return $apply(F, V, args);
 };

--- a/2017/Call.js
+++ b/2017/Call.js
@@ -1,19 +1,13 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
+var callBound = require('../helpers/callBound');
 
-var $TypeError = GetIntrinsic('%TypeError%');
-
-var inspect = require('object-inspect');
-
-var IsCallable = require('./IsCallable');
+var $apply = GetIntrinsic('%Reflect.apply%', true) || callBound('%Function.prototype.apply%');
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-call
 
 module.exports = function Call(F, V) {
 	var args = arguments.length > 2 ? arguments[2] : [];
-	if (!IsCallable(F)) {
-		throw new $TypeError(inspect(F) + ' is not a function');
-	}
-	return F.apply(V, args);
+	return $apply(F, V, args);
 };

--- a/2018/Call.js
+++ b/2018/Call.js
@@ -1,19 +1,13 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
+var callBound = require('../helpers/callBound');
 
-var $TypeError = GetIntrinsic('%TypeError%');
-
-var inspect = require('object-inspect');
-
-var IsCallable = require('./IsCallable');
+var $apply = GetIntrinsic('%Reflect.apply%', true) || callBound('%Function.prototype.apply%');
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-call
 
 module.exports = function Call(F, V) {
 	var args = arguments.length > 2 ? arguments[2] : [];
-	if (!IsCallable(F)) {
-		throw new $TypeError(inspect(F) + ' is not a function');
-	}
-	return F.apply(V, args);
+	return $apply(F, V, args);
 };

--- a/2019/Call.js
+++ b/2019/Call.js
@@ -1,19 +1,13 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
+var callBound = require('../helpers/callBound');
 
-var $TypeError = GetIntrinsic('%TypeError%');
-
-var inspect = require('object-inspect');
-
-var IsCallable = require('./IsCallable');
+var $apply = GetIntrinsic('%Reflect.apply%', true) || callBound('%Function.prototype.apply%');
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-call
 
 module.exports = function Call(F, V) {
 	var args = arguments.length > 2 ? arguments[2] : [];
-	if (!IsCallable(F)) {
-		throw new $TypeError(inspect(F) + ' is not a function');
-	}
-	return F.apply(V, args);
+	return $apply(F, V, args);
 };

--- a/helpers/callBind.js
+++ b/helpers/callBind.js
@@ -4,14 +4,14 @@ var bind = require('function-bind');
 
 var GetIntrinsic = require('../GetIntrinsic');
 
-var $Function = GetIntrinsic('%Function%');
-var $apply = $Function.apply;
-var $call = $Function.call;
+var $apply = GetIntrinsic('%Function.prototype.apply%');
+var $call = GetIntrinsic('%Function.prototype.call%');
+var $reflectApply = GetIntrinsic('%Reflect.apply%', true) || bind.call($call, $apply);
 
 module.exports = function callBind() {
-	return bind.apply($call, arguments);
+	return $reflectApply(bind, $call, arguments);
 };
 
 module.exports.apply = function applyBind() {
-	return bind.apply($apply, arguments);
+	return $reflectApply(bind, $apply, arguments);
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -610,7 +610,7 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 	test('Call', function (t) {
 		var receiver = {};
 		var notFuncs = v.nonFunctions.concat([/a/g, new RegExp('a', 'g')]);
-		t.plan(notFuncs.length + 4);
+		t.plan(notFuncs.length + 5);
 		var throwsIfNotCallable = function (notFunc) {
 			t['throws'](
 				function () { return ES.Call(notFunc, receiver); },
@@ -629,6 +629,25 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 			receiver,
 			[1, 2, 3]
 		);
+
+		t.test('Call doesn’t use func.apply', function (st) {
+			st.plan(4);
+
+			var bad = function (a, b) {
+				st.equal(this, receiver, 'context matches expected');
+				st.deepEqual([a, b], [1, 2], 'named args are correct');
+				st.equal(arguments.length, 3, 'extra argument was passed');
+				st.equal(arguments[2], 3, 'extra argument was correct');
+			};
+
+			bad.apply = function () {
+				st.fail('bad.apply shouldn’t get called');
+			};
+
+			ES.Call(bad, receiver, [1, 2, 3]);
+			st.end();
+		});
+
 		t.end();
 	});
 


### PR DESCRIPTION
This fixes the case where a function with an overriden `apply` property or without `%Function.prototype%` in its prototype chain were passed to `Call`, which would cause the call to fail.

This also removes the need for `!IsCallable(F)` in `Call`, as it’s handled by `Reflect.apply(…)` and the `callBound('%Function.prototype.apply%')` fallback.