### PR TITLE
[Fix] `Set`: Avoid observable `[[Get]]` where possible

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -1028,7 +1028,9 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 			);
 
 			st.doesNotThrow(
-				function () { ES.Set(obj, 'a', {}, false); },
+				function () {
+					st.equal(ES.Set(obj, 'a', {}, false), false, 'unsuccessful Set returns false');
+				},
 				'setting Throw to false prevents an exception'
 			);
 
@@ -1039,8 +1041,28 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 			var obj = { a: value };
 			defineProperty(obj, 'a', { configurable: false });
 
-			ES.Set(obj, 'a', value, true);
+			st.equal(ES.Set(obj, 'a', value, true), true, 'successful Set returns true');
 			st.deepEqual(obj, { a: value }, 'key is set');
+
+			st.end();
+		});
+
+		t.test('doesn’t call [[Get]] in conforming strict mode environments', { skip: noThrowOnStrictViolation }, function (st) {
+			var getterCalled = false;
+			var setterCalls = 0;
+			var obj = {};
+			defineProperty(obj, 'a', {
+				get: function () {
+					getterCalled = true;
+				},
+				set: function () {
+					setterCalls += 1;
+				}
+			});
+
+			st.equal(ES.Set(obj, 'a', value, false), true, 'successful Set returns true');
+			st.equal(setterCalls, 1, 'setter was called once');
+			st.equal(getterCalled, false, 'getter was not called');
 
 			st.end();
 		});


### PR DESCRIPTION
<https://github.com/ljharb/es-abstract/commit/7a963e3939da431e994d2181875f95b1e8ab239e> made it so that `Set` invokes the `[[Get]]` internal method when `Throw` is set, regardless of whether the environment is **IE 9**.

This makes it so that the observable `[[Get]]` call isn’t performed in environments that correctly throw when attempting to set read‑only properties.

This also fixes the bug where `Set` would return `undefined` for successful sets when `Throw === false`.