### PR TITLE
[Breaking] `GetIntrinsic`: restrict intrinsic syntax

### DIFF
--- a/test/GetIntrinsic.js
+++ b/test/GetIntrinsic.js
@@ -34,6 +34,36 @@ test('throws', function (t) {
 		'"just a dot" intrinsic throws a syntax error'
 	);
 
+	t['throws'](
+		function () { GetIntrinsic('%String'); },
+		SyntaxError,
+		'Leading % without trailing % throws a syntax error'
+	);
+
+	t['throws'](
+		function () { GetIntrinsic('String%'); },
+		SyntaxError,
+		'Trailing % without leading % throws a syntax error'
+	);
+
+	t['throws'](
+		function () { GetIntrinsic('String["prototype"]'); },
+		SyntaxError,
+		'Dynamic property access is disallowed for intrinsics (double quote)'
+	);
+
+	t['throws'](
+		function () { GetIntrinsic("String['prototype']"); },
+		SyntaxError,
+		'Dynamic property access is disallowed for intrinsics (single quote)'
+	);
+
+	t['throws'](
+		function () { GetIntrinsic("String['prototype]"); },
+		SyntaxError,
+		'Dynamic property access is disallowed for intrinsics (unterminated string)'
+	);
+
 	forEach(v.nonStrings, function (nonString) {
 		t['throws'](
 			function () { GetIntrinsic(nonString); },


### PR DESCRIPTION
This makes it so that the intrinsic name has to either be enclosed by `%`, or the enclosing `%`‑signs must be omitted, but it’s invalid to include only one of them.

This also disallows dynamic property access, since it’s not allowed by the spec.