### PR TITLE
[Fix] `SameValue`: Use `Object.is(…)` if available

### DIFF
--- a/2015/SameValue.js
+++ b/2015/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2016/SameValue.js
+++ b/2016/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2017/SameValue.js
+++ b/2017/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2018/SameValue.js
+++ b/2018/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2019/SameValue.js
+++ b/2019/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2020/SameValue.js
+++ b/2020/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2021/SameValue.js
+++ b/2021/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2022/SameValue.js
+++ b/2022/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2023/SameValue.js
+++ b/2023/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/2024/SameValue.js
+++ b/2024/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;

--- a/5/SameValue.js
+++ b/5/SameValue.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var GetIntrinsic = require('get-intrinsic');
 var $isNaN = require('math-intrinsics/isNaN');
 
 // http://262.ecma-international.org/5.1/#sec-9.12
 
-module.exports = function SameValue(x, y) {
+module.exports = GetIntrinsic('%Object.is%', true) || function SameValue(x, y) {
 	if (x === y) { // 0 === -0, but they are not identical.
 		if (x === 0) { return 1 / x === 1 / y; }
 		return true;


### PR DESCRIPTION
[`Object.is(…)`](https://tc39.es/ecma262/#sec-object.is) simply invokes the `SameValue` abstract operation.