### PR TITLE
[Fix]: `helpers/callBound`: Avoid useless `$indexOf` call

### DIFF
--- a/helpers/callBound.js
+++ b/helpers/callBound.js
@@ -1,14 +1,11 @@
 'use strict';
 
 var GetIntrinsic = require('../GetIntrinsic');
-
 var callBind = require('./callBind');
-
-var $indexOf = callBind(GetIntrinsic('String.prototype.indexOf'));
 
 module.exports = function callBoundIntrinsic(name, allowMissing) {
 	var intrinsic = GetIntrinsic(name, !!allowMissing);
-	if (typeof intrinsic === 'function' && $indexOf(name, '.prototype.')) {
+	if (typeof intrinsic === 'function') {
 		return callBind(intrinsic);
 	}
 	return intrinsic;


### PR DESCRIPTION
<code>[%String.prototype.indexOf%]</code> returns `‑1` when the substring wasn’t found, and <code>[ToBoolean][]\(‑1\)</code> returns `true`, so the correct check should’ve been `$indexOf(name, '.prototype.') > 0`, but doing that now would break many things, including <code>PromiseResolve</code>.

The only case where `callBound` could return the same function object as `GetIntrinsic` would’ve been `callBound('.prototype.something')` <sup>(`callBound('%.prototype.something%')` would return the result of `callBind`, as the index of `'.prototype.'` is `1`),</sup> but that would cause `GetIntrinsic` to throw a `SyntaxError`.

[%String.prototype.indexOf%]: https://tc39.es/ecma262/#sec-string.prototype.indexof
[ToBoolean]: https://tc39.es/ecma262/#sec-toboolean