### PR TITLE
Adapt to override-mistake-fix pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ matrix:
       env: TEST=true
     - node_js: "0.8"
       env: TEST=true
+  allow_failures:
+    - env: SES=true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ import:
  - ljharb/travis-ci:node/posttest.yml
 script:
   - 'if [ -n "${COVERAGE-}" ]; then npm run coverage && bash <(curl -s https://codecov.io/bash) -f coverage/*.json; fi'
+  - 'if [ -n "${SES-}" ]; then node test/ses-compat; fi'
 matrix:
   include:
     - node_js: "8"
@@ -25,6 +26,8 @@ matrix:
       env: COVERAGE=true
     - node_js: "0.8"
       env: COVERAGE=true
+    - node_js: "lts/*"
+      env: SES=true
   exclude:
     - node_js: "0.12"
       env: TEST=true

--- a/GetIntrinsic.js
+++ b/GetIntrinsic.js
@@ -263,7 +263,18 @@ module.exports = function GetIntrinsic(name, allowMissing) {
 				if (!allowMissing && !(part in value)) {
 					throw new $TypeError('base intrinsic for ' + name + ' exists, but the property is not available.');
 				}
-				value = isOwn ? desc.get || desc.value : value[part];
+				// By convention, when a data property is converted to an accessor
+				// property to emulate a data property that does not suffer from
+				// the override mistake, that accessor's getter is marked with
+				// an `originalValue` property. Here, when we detect this, we
+				// uphold the illusion by pretending to see that original data
+				// property, i.e., returning the value rather than the getter
+				// itself.
+				if (isOwn && 'get' in desc && !('originalValue' in desc.get)) {
+					value = desc.get;
+				} else {
+					value = value[part];
+				}
 			} else {
 				isOwn = hasOwn(value, part);
 				value = value[part];

--- a/helpers/callBind.js
+++ b/helpers/callBind.js
@@ -8,10 +8,27 @@ var $apply = GetIntrinsic('%Function.prototype.apply%');
 var $call = GetIntrinsic('%Function.prototype.call%');
 var $reflectApply = GetIntrinsic('%Reflect.apply%', true) || bind.call($call, $apply);
 
+var $defineProperty = GetIntrinsic('%Object.defineProperty%', true);
+
+if ($defineProperty) {
+	try {
+		$defineProperty({}, 'a', { value: 1 });
+	} catch (e) {
+		// IE 8 has a broken defineProperty
+		$defineProperty = null;
+	}
+}
+
 module.exports = function callBind() {
 	return $reflectApply(bind, $call, arguments);
 };
 
-module.exports.apply = function applyBind() {
+var applyBind = function applyBind() {
 	return $reflectApply(bind, $apply, arguments);
 };
+
+if ($defineProperty) {
+	$defineProperty(module.exports, 'apply', { value: applyBind });
+} else {
+	module.exports.apply = applyBind;
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"object-is": "^1.1.2",
 		"object.fromentries": "^2.0.2",
 		"safe-publish-latest": "^1.1.4",
+		"ses": "^0.10.4",
 		"tape": "^5.0.1"
 	},
 	"testling": {

--- a/test/GetIntrinsic.js
+++ b/test/GetIntrinsic.js
@@ -88,7 +88,7 @@ test('dotted paths', function (t) {
 	t.equal(GetIntrinsic('%Array.prototype.push%'), Array.prototype.push, '%Array.prototype.push% yields Array.prototype.push');
 	t.equal(GetIntrinsic('Array.prototype.push'), Array.prototype.push, 'Array.prototype.push yields Array.prototype.push');
 
-	test('underscore paths are aliases for dotted paths', function (st) {
+	test('underscore paths are aliases for dotted paths', { skip: !Object.isFrozen || Object.isFrozen(Object.prototype) }, function (st) {
 		var original = GetIntrinsic('%ObjProto_toString%');
 
 		forEach([
@@ -111,7 +111,7 @@ test('dotted paths', function (t) {
 		st.end();
 	});
 
-	test('dotted paths cache', function (st) {
+	test('dotted paths cache', { skip: !Object.isFrozen || Object.isFrozen(Object.prototype) }, function (st) {
 		var original = GetIntrinsic('%Object.prototype.propertyIsEnumerable%');
 
 		forEach([

--- a/test/ses-compat.js
+++ b/test/ses-compat.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/* globals lockdown */
+require('ses');
+
+lockdown({ errorTaming: 'unsafe' });
+
+require('.');

--- a/test/tests.js
+++ b/test/tests.js
@@ -2700,16 +2700,18 @@ var es2015 = function ES2015(ES, ops, expectedMissing, skips) {
 			'array length yields expected descriptor'
 		);
 
-		t.deepEqual(
-			ES.OrdinaryGetOwnProperty(Object.prototype, 'toString'),
-			ES.ToPropertyDescriptor({
-				configurable: true,
-				enumerable: false,
-				value: Object.prototype.toString,
-				writable: true
-			}),
-			'own non-enumerable data property yields expected descriptor'
-		);
+		if (!Object.isFrozen || !Object.isFrozen(Object.prototype)) {
+			t.deepEqual(
+				ES.OrdinaryGetOwnProperty(Object.prototype, 'toString'),
+				ES.ToPropertyDescriptor({
+					configurable: true,
+					enumerable: false,
+					value: Object.prototype.toString,
+					writable: true
+				}),
+				'own non-enumerable data property yields expected descriptor'
+			);
+		}
 
 		t.test('ES5+', { skip: !defineProperty.oDP }, function (st) {
 			var O = {};


### PR DESCRIPTION
Fixes https://github.com/ljharb/object.assign/issues/79

Detect when the getter of an accessor
alleges that it was originally a data property. This enables a
leaky and cooperative partial emulation of the original data property,
as code such as this uses this property to uphold the illusion.
See https://github.com/ljharb/object.assign/issues/79 and
https://github.com/Agoric/SES-shim/pull/473#issuecomment-697187652

Closes #113. Closes #114.