### PR TITLE
[Fix] `ES2018+`: fix `GetSubstitution` with named captures

### DIFF
--- a/2018/GetSubstitution.js
+++ b/2018/GetSubstitution.js
@@ -106,13 +106,13 @@ module.exports = function GetSubstitution(matched, str, position, captures, name
 						var endIndex = $indexOf(replacement, '>', i);
 						// eslint-disable-next-line max-depth
 						if (endIndex > -1) {
-							var groupName = $strSlice(replacement, i, endIndex);
+							var groupName = $strSlice(replacement, i + '$<'.length, endIndex);
 							var capture = Get(namedCaptures, groupName);
 							// eslint-disable-next-line max-depth
 							if (Type(capture) !== 'Undefined') {
 								result += ToString(capture);
 							}
-							i += '$<' + groupName + '>'.length;
+							i += ('<' + groupName + '>').length;
 						}
 					}
 				} else {

--- a/2019/GetSubstitution.js
+++ b/2019/GetSubstitution.js
@@ -106,13 +106,13 @@ module.exports = function GetSubstitution(matched, str, position, captures, name
 						var endIndex = $indexOf(replacement, '>', i);
 						// eslint-disable-next-line max-depth
 						if (endIndex > -1) {
-							var groupName = $strSlice(replacement, i, endIndex);
+							var groupName = $strSlice(replacement, i + '$<'.length, endIndex);
 							var capture = Get(namedCaptures, groupName);
 							// eslint-disable-next-line max-depth
 							if (Type(capture) !== 'Undefined') {
 								result += ToString(capture);
 							}
-							i += '$<' + groupName + '>'.length;
+							i += ('<' + groupName + '>').length;
 						}
 					}
 				} else {

--- a/2020/GetSubstitution.js
+++ b/2020/GetSubstitution.js
@@ -106,13 +106,13 @@ module.exports = function GetSubstitution(matched, str, position, captures, name
 						var endIndex = $indexOf(replacement, '>', i);
 						// eslint-disable-next-line max-depth
 						if (endIndex > -1) {
-							var groupName = $strSlice(replacement, i, endIndex);
+							var groupName = $strSlice(replacement, i + '$<'.length, endIndex);
 							var capture = Get(namedCaptures, groupName);
 							// eslint-disable-next-line max-depth
 							if (Type(capture) !== 'Undefined') {
 								result += ToString(capture);
 							}
-							i += '$<' + groupName + '>'.length;
+							i += ('<' + groupName + '>').length;
 						}
 					}
 				} else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4194,6 +4194,20 @@ var es2018 = function ES2018(ES, ops, expectedMissing, skips) {
 			}
 		}
 
+		t.test('named captures', function (st) {
+			var namedCaptures = {
+				foo: 'foo!'
+			};
+
+			st.equal(
+				ES.GetSubstitution('abcdef', 'abcdefghi', 0, captures, namedCaptures, 'a>$<foo><z'),
+				'a>foo!<z',
+				'supports named captures'
+			);
+
+			st.end();
+		});
+
 		t.end();
 	});
 


### PR DESCRIPTION
line https://github.com/es-shims/es-abstract/blob/2b693d9d4f6c84011191018c1b6a18a4705c5958/2020/GetSubstitution.js#L115

has some code the looks buggy as 

`'>'.length `

will be executed first leading it to always be 1 and so you get  

 `'$<' + groupName + 1`

most likely 
 ` ('$<' + groupName + '>').length`  

would be more correct