### PR TITLE
Exclude dot files from the testing sweep

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 	"devDependencies": {
 		"@ljharb/eslint-config": "^18.0.0",
 		"array.prototype.indexof": "^1.0.2",
+		"array.prototype.filter": "^1.0.0",
 		"aud": "^1.1.5",
 		"cheerio": "=1.0.0-rc.3",
 		"diff": "^5.0.0",

--- a/test/helpers/runManifestTest.js
+++ b/test/helpers/runManifestTest.js
@@ -3,12 +3,16 @@
 var path = require('path');
 var fs = require('fs');
 
+var filter = require('array.prototype.filter');
 var forEach = require('foreach');
 var keys = require('object-keys');
 
 module.exports = function runManifestTest(test, ES, edition) {
 	test('ES' + edition + ' manifest', { skip: !fs.readdirSync }, function (t) {
-		var files = fs.readdirSync(path.join(__dirname, '../../' + edition), 'utf-8');
+		var files = filter(
+			fs.readdirSync(path.join(__dirname, '../../' + edition), 'utf-8'),
+			function rejectDotFile(file) { return file[0] !== '.'; }
+		);
 		var map = {
 			AbstractEqualityComparison: 'Abstract Equality Comparison',
 			AbstractRelationalComparison: 'Abstract Relational Comparison',


### PR DESCRIPTION
This notably results in ignoring swap files from vi(m).