### PR TITLE
[Fix] `ES2021+`: values that truncate to -0 in `ToIntegerOrInfinity`

### DIFF
--- a/2021/ToIntegerOrInfinity.js
+++ b/2021/ToIntegerOrInfinity.js
@@ -14,5 +14,7 @@ module.exports = function ToIntegerOrInfinity(value) {
 	var number = ToNumber(value);
 	if ($isNaN(number) || number === 0) { return 0; }
 	if (!$isFinite(number)) { return number; }
-	return $sign(number) * floor(abs(number));
+	var integer = floor(abs(number));
+	if (integer === 0) { return 0; }
+	return $sign(number) * integer;
 };

--- a/2022/ToIntegerOrInfinity.js
+++ b/2022/ToIntegerOrInfinity.js
@@ -14,5 +14,7 @@ module.exports = function ToIntegerOrInfinity(value) {
 	var number = ToNumber(value);
 	if ($isNaN(number) || number === 0) { return 0; }
 	if (!$isFinite(number)) { return number; }
-	return $sign(number) * floor(abs(number));
+	var integer = floor(abs(number));
+	if (integer === 0) { return 0; }
+	return $sign(number) * integer;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -7655,13 +7655,14 @@ var es2020 = function ES2020(ES, ops, expectedMissing, skips) {
 
 	test('ToInteger', function (t) {
 		forEach([0, -0, NaN], function (num) {
-			t.equal(0, ES.ToInteger(num), debug(num) + ' returns +0');
+			t.equal(ES.ToInteger(num), +0, debug(num) + ' returns +0');
 		});
 		forEach([Infinity, 42], function (num) {
-			t.equal(num, ES.ToInteger(num), debug(num) + ' returns itself');
-			t.equal(-num, ES.ToInteger(-num), '-' + debug(num) + ' returns itself');
+			t.equal(ES.ToInteger(num), num, debug(num) + ' returns itself');
+			t.equal(ES.ToInteger(-num), -num, '-' + debug(num) + ' returns itself');
 		});
-		t.equal(3, ES.ToInteger(Math.PI), 'pi returns 3');
+		t.equal(ES.ToInteger(Math.PI), 3, 'pi returns 3');
+		t.equal(ES.ToInteger(-0.1), +0, '-0.1 truncates to +0, not -0');
 		t['throws'](function () { return ES.ToInteger(v.uncoercibleObject); }, TypeError, 'uncoercibleObject throws');
 		t.end();
 	});
@@ -8149,13 +8150,14 @@ var es2021 = function ES2021(ES, ops, expectedMissing, skips) {
 
 	test('ToIntegerOrInfinity', function (t) {
 		forEach([0, -0, NaN], function (num) {
-			t.equal(0, ES.ToIntegerOrInfinity(num), debug(num) + ' returns +0');
+			t.equal(ES.ToIntegerOrInfinity(num), +0, debug(num) + ' returns +0');
 		});
 		forEach([Infinity, 42], function (num) {
-			t.equal(num, ES.ToIntegerOrInfinity(num), debug(num) + ' returns itself');
-			t.equal(-num, ES.ToIntegerOrInfinity(-num), '-' + debug(num) + ' returns itself');
+			t.equal(ES.ToIntegerOrInfinity(num), num, debug(num) + ' returns itself');
+			t.equal(ES.ToIntegerOrInfinity(-num), -num, '-' + debug(num) + ' returns itself');
 		});
-		t.equal(3, ES.ToIntegerOrInfinity(Math.PI), 'pi returns 3');
+		t.equal(ES.ToIntegerOrInfinity(Math.PI), 3, 'pi returns 3');
+		t.equal(ES.ToIntegerOrInfinity(-0.1), +0, '-0.1 truncates to +0, not -0');
 		t['throws'](function () { return ES.ToIntegerOrInfinity(v.uncoercibleObject); }, TypeError, 'uncoercibleObject throws');
 		t.end();
 	});


### PR DESCRIPTION
ToIntegerOrInfinity(-0.1) should return 0, not -0.

This was also the case in ES2020's ToInteger (but not in earlier versions) so this adds a similar test to ES2020's tests as well, although no fix is needed there.