### PR TITLE
[Fix] `ES2016`+: `UTF16Decode` and friends, `CodePointAt`, `StringToCodePoints`: return numbers instead of strings

### DIFF
--- a/2016/UTF16Decode.js
+++ b/2016/UTF16Decode.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 // https://262.ecma-international.org/7.0/#sec-utf16decode
 
@@ -16,6 +15,5 @@ module.exports = function UTF16Decode(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2017/UTF16Decode.js
+++ b/2017/UTF16Decode.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 // https://262.ecma-international.org/7.0/#sec-utf16decode
 
@@ -16,6 +15,5 @@ module.exports = function UTF16Decode(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2018/UTF16Decode.js
+++ b/2018/UTF16Decode.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 // https://262.ecma-international.org/7.0/#sec-utf16decode
 
@@ -16,6 +15,5 @@ module.exports = function UTF16Decode(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2019/UTF16Decode.js
+++ b/2019/UTF16Decode.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 // https://262.ecma-international.org/7.0/#sec-utf16decode
 
@@ -16,6 +15,5 @@ module.exports = function UTF16Decode(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2020/CodePointAt.js
+++ b/2020/CodePointAt.js
@@ -10,7 +10,6 @@ var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
 var Type = require('./Type');
 var UTF16DecodeSurrogatePair = require('./UTF16DecodeSurrogatePair');
 
-var $charAt = callBound('String.prototype.charAt');
 var $charCodeAt = callBound('String.prototype.charCodeAt');
 
 // https://262.ecma-international.org/11.0/#sec-codepointat
@@ -24,19 +23,18 @@ module.exports = function CodePointAt(string, position) {
 		throw new $TypeError('Assertion failed: `position` must be >= 0, and < the length of `string`');
 	}
 	var first = $charCodeAt(string, position);
-	var cp = $charAt(string, position);
 	var firstIsLeading = isLeadingSurrogate(first);
 	var firstIsTrailing = isTrailingSurrogate(first);
 	if (!firstIsLeading && !firstIsTrailing) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		};
 	}
 	if (firstIsTrailing || (position + 1 === size)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};
@@ -44,7 +42,7 @@ module.exports = function CodePointAt(string, position) {
 	var second = $charCodeAt(string, position + 1);
 	if (!isTrailingSurrogate(second)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};

--- a/2020/QuoteJSONString.js
+++ b/2020/QuoteJSONString.js
@@ -36,7 +36,8 @@ module.exports = function QuoteJSONString(value) {
 	}
 	var product = '"';
 	if (value) {
-		forEach(UTF16DecodeString(value), function (C) {
+		forEach(UTF16DecodeString(value), function (CP) {
+			var C = UTF16Encoding(CP);
 			if (has(escapes, C)) {
 				product += escapes[C];
 			} else {

--- a/2020/UTF16DecodeSurrogatePair.js
+++ b/2020/UTF16DecodeSurrogatePair.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 var isLeadingSurrogate = require('../helpers/isLeadingSurrogate');
 var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
@@ -14,6 +13,5 @@ module.exports = function UTF16DecodeSurrogatePair(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2021/CodePointAt.js
+++ b/2021/CodePointAt.js
@@ -10,7 +10,6 @@ var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
 var Type = require('./Type');
 var UTF16SurrogatePairToCodePoint = require('./UTF16SurrogatePairToCodePoint');
 
-var $charAt = callBound('String.prototype.charAt');
 var $charCodeAt = callBound('String.prototype.charCodeAt');
 
 // https://262.ecma-international.org/12.0/#sec-codepointat
@@ -24,19 +23,18 @@ module.exports = function CodePointAt(string, position) {
 		throw new $TypeError('Assertion failed: `position` must be >= 0, and < the length of `string`');
 	}
 	var first = $charCodeAt(string, position);
-	var cp = $charAt(string, position);
 	var firstIsLeading = isLeadingSurrogate(first);
 	var firstIsTrailing = isTrailingSurrogate(first);
 	if (!firstIsLeading && !firstIsTrailing) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		};
 	}
 	if (firstIsTrailing || (position + 1 === size)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};
@@ -44,7 +42,7 @@ module.exports = function CodePointAt(string, position) {
 	var second = $charCodeAt(string, position + 1);
 	if (!isTrailingSurrogate(second)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};

--- a/2021/QuoteJSONString.js
+++ b/2021/QuoteJSONString.js
@@ -36,7 +36,8 @@ module.exports = function QuoteJSONString(value) {
 	}
 	var product = '"';
 	if (value) {
-		forEach(StringToCodePoints(value), function (C) {
+		forEach(StringToCodePoints(value), function (CP) {
+			var C = UTF16EncodeCodePoint(CP);
 			if (has(escapes, C)) {
 				product += escapes[C];
 			} else {

--- a/2021/UTF16SurrogatePairToCodePoint.js
+++ b/2021/UTF16SurrogatePairToCodePoint.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 var isLeadingSurrogate = require('../helpers/isLeadingSurrogate');
 var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
@@ -14,6 +13,5 @@ module.exports = function UTF16SurrogatePairToCodePoint(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/2022/CodePointAt.js
+++ b/2022/CodePointAt.js
@@ -10,7 +10,6 @@ var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
 var Type = require('./Type');
 var UTF16SurrogatePairToCodePoint = require('./UTF16SurrogatePairToCodePoint');
 
-var $charAt = callBound('String.prototype.charAt');
 var $charCodeAt = callBound('String.prototype.charCodeAt');
 
 // https://262.ecma-international.org/12.0/#sec-codepointat
@@ -24,19 +23,18 @@ module.exports = function CodePointAt(string, position) {
 		throw new $TypeError('Assertion failed: `position` must be >= 0, and < the length of `string`');
 	}
 	var first = $charCodeAt(string, position);
-	var cp = $charAt(string, position);
 	var firstIsLeading = isLeadingSurrogate(first);
 	var firstIsTrailing = isTrailingSurrogate(first);
 	if (!firstIsLeading && !firstIsTrailing) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		};
 	}
 	if (firstIsTrailing || (position + 1 === size)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};
@@ -44,7 +42,7 @@ module.exports = function CodePointAt(string, position) {
 	var second = $charCodeAt(string, position + 1);
 	if (!isTrailingSurrogate(second)) {
 		return {
-			'[[CodePoint]]': cp,
+			'[[CodePoint]]': first,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		};

--- a/2022/GetStringIndex.js
+++ b/2022/GetStringIndex.js
@@ -8,6 +8,7 @@ var $TypeError = GetIntrinsic('%TypeError%');
 var IsIntegralNumber = require('./IsIntegralNumber');
 var StringToCodePoints = require('./StringToCodePoints');
 var Type = require('./Type');
+var UTF16EncodeCodePoint = require('./UTF16EncodeCodePoint');
 
 var $indexOf = callBound('String.prototype.indexOf');
 
@@ -25,6 +26,6 @@ module.exports = function GetStringIndex(S, e) {
 		return 0;
 	}
 	var codepoints = StringToCodePoints(S);
-	var eUTF = e >= codepoints.length ? S.length : $indexOf(S, codepoints[e]);
+	var eUTF = e >= codepoints.length ? S.length : $indexOf(S, UTF16EncodeCodePoint(codepoints[e]));
 	return eUTF;
 };

--- a/2022/QuoteJSONString.js
+++ b/2022/QuoteJSONString.js
@@ -36,7 +36,8 @@ module.exports = function QuoteJSONString(value) {
 	}
 	var product = '"';
 	if (value) {
-		forEach(StringToCodePoints(value), function (C) {
+		forEach(StringToCodePoints(value), function (CP) {
+			var C = UTF16EncodeCodePoint(CP);
 			if (has(escapes, C)) {
 				product += escapes[C];
 			} else {

--- a/2022/UTF16SurrogatePairToCodePoint.js
+++ b/2022/UTF16SurrogatePairToCodePoint.js
@@ -3,7 +3,6 @@
 var GetIntrinsic = require('get-intrinsic');
 
 var $TypeError = GetIntrinsic('%TypeError%');
-var $fromCharCode = GetIntrinsic('%String.fromCharCode%');
 
 var isLeadingSurrogate = require('../helpers/isLeadingSurrogate');
 var isTrailingSurrogate = require('../helpers/isTrailingSurrogate');
@@ -14,6 +13,5 @@ module.exports = function UTF16SurrogatePairToCodePoint(lead, trail) {
 	if (!isLeadingSurrogate(lead) || !isTrailingSurrogate(trail)) {
 		throw new $TypeError('Assertion failed: `lead` must be a leading surrogate char code, and `trail` must be a trailing surrogate char code');
 	}
-	// var cp = (lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000;
-	return $fromCharCode(lead) + $fromCharCode(trail);
+	return ((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -171,6 +171,15 @@ Test.prototype.throwsSentinel = function throwsSentinel(fn, sentinel, message) {
 var leadingPoo = '\uD83D';
 var trailingPoo = '\uDCA9';
 var wholePoo = leadingPoo + trailingPoo;
+var codePoints = {
+	a: 97,
+	b: 98,
+	c: 99,
+	d: 100,
+	leadingPoo: 55357,
+	trailingPoo: 56489,
+	wholePoo: 128169
+};
 
 var getArraySubclassWithSpeciesConstructor = function getArraySubclass(speciesConstructor) {
 	var Bar = function Bar() {
@@ -5264,7 +5273,7 @@ var es2016 = function ES2016(ES, ops, expectedMissing, skips) {
 			'"b" is not a trailing surrogate'
 		);
 
-		t.equal(ES.UTF16Decode(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), wholePoo);
+		t.equal(ES.UTF16Decode(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), codePoints.wholePoo);
 
 		t.end();
 	});
@@ -8331,17 +8340,17 @@ var es2020 = function ES2020(ES, ops, expectedMissing, skips) {
 		);
 
 		t.deepEqual(ES.CodePointAt('abc', 0), {
-			'[[CodePoint]]': 'a',
+			'[[CodePoint]]': codePoints.a,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
 		t.deepEqual(ES.CodePointAt('abc', 1), {
-			'[[CodePoint]]': 'b',
+			'[[CodePoint]]': codePoints.b,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
 		t.deepEqual(ES.CodePointAt('abc', 2), {
-			'[[CodePoint]]': 'c',
+			'[[CodePoint]]': codePoints.c,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
@@ -8350,38 +8359,38 @@ var es2020 = function ES2020(ES, ops, expectedMissing, skips) {
 		var strWithWholePoo = 'a' + wholePoo + 'd';
 
 		t.deepEqual(ES.CodePointAt(strWithHalfPoo, 0), {
-			'[[CodePoint]]': 'a',
+			'[[CodePoint]]': codePoints.a,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
 		t.deepEqual(ES.CodePointAt(strWithHalfPoo, 1), {
-			'[[CodePoint]]': leadingPoo,
+			'[[CodePoint]]': codePoints.leadingPoo,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		});
 		t.deepEqual(ES.CodePointAt(strWithHalfPoo, 2), {
-			'[[CodePoint]]': 'c',
+			'[[CodePoint]]': codePoints.c,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
 
 		t.deepEqual(ES.CodePointAt(strWithWholePoo, 0), {
-			'[[CodePoint]]': 'a',
+			'[[CodePoint]]': codePoints.a,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
 		t.deepEqual(ES.CodePointAt(strWithWholePoo, 1), {
-			'[[CodePoint]]': wholePoo,
+			'[[CodePoint]]': codePoints.wholePoo,
 			'[[CodeUnitCount]]': 2,
 			'[[IsUnpairedSurrogate]]': false
 		});
 		t.deepEqual(ES.CodePointAt(strWithWholePoo, 2), {
-			'[[CodePoint]]': trailingPoo,
+			'[[CodePoint]]': codePoints.trailingPoo,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': true
 		});
 		t.deepEqual(ES.CodePointAt(strWithWholePoo, 3), {
-			'[[CodePoint]]': 'd',
+			'[[CodePoint]]': codePoints.d,
 			'[[CodeUnitCount]]': 1,
 			'[[IsUnpairedSurrogate]]': false
 		});
@@ -10922,7 +10931,7 @@ var es2020 = function ES2020(ES, ops, expectedMissing, skips) {
 			'"b" is not a trailing surrogate'
 		);
 
-		t.equal(ES.UTF16DecodeSurrogatePair(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), wholePoo);
+		t.equal(ES.UTF16DecodeSurrogatePair(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), codePoints.wholePoo);
 
 		t.end();
 	});
@@ -10984,8 +10993,8 @@ var es2020 = function ES2020(ES, ops, expectedMissing, skips) {
 			);
 		});
 
-		t.deepEqual(ES.UTF16DecodeString('abc'), ['a', 'b', 'c'], 'code units get split');
-		t.deepEqual(ES.UTF16DecodeString('a' + wholePoo + 'c'), ['a', wholePoo, 'c'], 'code points get split too');
+		t.deepEqual(ES.UTF16DecodeString('abc'), [codePoints.a, codePoints.b, codePoints.c], 'code units get split');
+		t.deepEqual(ES.UTF16DecodeString('a' + wholePoo + 'c'), [codePoints.a, codePoints.wholePoo, codePoints.c], 'code points get split too');
 
 		t.end();
 	});
@@ -11521,8 +11530,8 @@ var es2021 = function ES2021(ES, ops, expectedMissing, skips) {
 			);
 		});
 
-		t.deepEqual(ES.StringToCodePoints('abc'), ['a', 'b', 'c'], 'code units get split');
-		t.deepEqual(ES.StringToCodePoints('a' + wholePoo + 'c'), ['a', wholePoo, 'c'], 'code points get split too');
+		t.deepEqual(ES.StringToCodePoints('abc'), [codePoints.a, codePoints.b, codePoints.c], 'code units get split');
+		t.deepEqual(ES.StringToCodePoints('a' + wholePoo + 'c'), [codePoints.a, codePoints.wholePoo, codePoints.c], 'code points get split too');
 
 		t.end();
 	});
@@ -11596,7 +11605,7 @@ var es2021 = function ES2021(ES, ops, expectedMissing, skips) {
 			'"b" is not a trailing surrogate'
 		);
 
-		t.equal(ES.UTF16SurrogatePairToCodePoint(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), wholePoo);
+		t.equal(ES.UTF16SurrogatePairToCodePoint(leadingPoo.charCodeAt(0), trailingPoo.charCodeAt(0)), codePoints.wholePoo);
 
 		t.end();
 	});


### PR DESCRIPTION
This PR modifies the following operations to return numbers, as [specified](https://tc39.es/ecma262/#sec-utf16decodesurrogatepair), instead of strings:
* `UTF16SurrogatePairToCodePoint`
* `UTF16DecodeSurrogatePair`
* `UTF16Decode`
* `UTF16DecodeString`
* `CodePointAt`
* `StringToCodePoints`

Resolves https://github.com/ljharb/es-abstract/issues/150.