### PR TITLE
[Robustness] Replace `isNegativeZero` helper with `is-negative-zero` dependency

### DIFF
--- a/helpers/isNegativeZero.js
+++ b/helpers/isNegativeZero.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// TODO, semver-major: remove
 module.exports = function isNegativeZero(x) {
 	return x === 0 && 1 / x === 1 / -0;
 };


### PR DESCRIPTION
As discussed in https://github.com/ljharb/es-abstract/pull/154 , replaced `isNegativeZero` with a dependency to remove unnecessary code duplication.